### PR TITLE
Fix problem when account names contains regexp characters

### DIFF
--- a/mu4e-multi.el
+++ b/mu4e-multi.el
@@ -97,8 +97,7 @@ If no account can be found from MSG then use ACCOUNT as default."
                 (string-match
                  (concat
                   "/\\("
-                  (regexp-opt
-                   (mapcar 'regexp-quote account-list))
+                  (regexp-opt account-list)
                   "\\)/?")
                  maildir))
            (match-string-no-properties 1 maildir))


### PR DESCRIPTION
'mu4e-multi-get-msg-account' fails when account name contains regular
expression characters such as ".". The reason is that account-list gets
double quoted for regular expressions: once from 'regexp-quote' and
another from 'regexp-opt'.

From the doc of 'regexp-opt':
  Each string should be unique in STRINGS and should _not_ contain any
  regexps, quoted or not.
