### PR TITLE
remove angles from email address if From: field

### DIFF
--- a/mu4e-multi.el
+++ b/mu4e-multi.el
@@ -201,9 +201,10 @@ keys of the `mu4e-multi-account-alist'."
          "-a"
          (catch 'exit
            (let* ((from (message-fetch-field "from"))
-                  (email (and from
-                              (string-match thing-at-point-email-regexp from)
-                              (match-string-no-properties 0 from))))
+                  (emaildirty (and from
+                                   (string-match thing-at-point-email-regexp from)
+                                   (match-string-no-properties 0 from)))
+                  (email (replace-regexp-in-string "[<>]" "" emaildirty)))
              (if email
                  (cl-dolist (alist mu4e-multi-account-alist)
                    (when (string= email (cdr (assoc 'user-mail-address (cdr alist))))


### PR DESCRIPTION
When I set 

```
(setq message-from-style 'angles) 
```

the From: field appears as 

```
My Name <my.name@address.com>
```

In this case, the function `mu4e-multi-smtpmail-set-msmtp-account` doesn't find the right account in the `.msmtprc` file. This pr removes the angles from the email address.
