### PR TITLE
Strip angle brackets to match 'user-mail-address

### DIFF
--- a/mu4e-multi.el
+++ b/mu4e-multi.el
@@ -203,7 +203,8 @@ keys of the `mu4e-multi-account-alist'."
            (let* ((from (message-fetch-field "from"))
                   (email (and from
                               (string-match thing-at-point-email-regexp from)
-                              (match-string-no-properties 0 from))))
+                              (match-string-no-properties 0 from)))
+                  (email (replace-regexp-in-string "[<>]" "" email)))
              (if email
                  (cl-dolist (alist mu4e-multi-account-alist)
                    (when (string= email (cdr (assoc 'user-mail-address (cdr alist))))


### PR DESCRIPTION
Angle brackets in the From address were making the extracted `email` not
match any of the 'user-mail-address properties. This fix strips the
angle brackets before comparing with entries in `mu4e-multi-account-alist`
