### PR TITLE
Support multiple user identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ set a `message-mode-hook` to detect and set the current account
 variables based on the email address. If for some reason you wish to
 rollback these changes, just call `mu4e-multi-disable`.
 
+In addition to the primary email address of an account identified by the `user-mail-address` key, there may also be a `user-mail-identities` key which contains a list of email addresses that are treated as aliases to the primary address.
+
 ### Custom folders and markers
 
 Notice that, in our example, the `mu4e-hold-folder`and

--- a/mu4e-multi.el
+++ b/mu4e-multi.el
@@ -32,7 +32,7 @@
 (require 'mu4e-actions)
 (require 'mu4e-headers)
 (require 'thingatpt)
-
+(require 'subr-x)
 
 (defvar mu4e-multi-last-read-account ""
   "Holds the last selected account from minibuffer.
@@ -207,7 +207,11 @@ keys of the `mu4e-multi-account-alist'."
                   (email (replace-regexp-in-string "[<>]" "" email)))
              (if email
                  (cl-dolist (alist mu4e-multi-account-alist)
-                   (when (string= email (cdr (assoc 'user-mail-address (cdr alist))))
+                   (when (or (string= email
+                                      (alist-get 'user-mail-address
+                                                 (cdr alist)))
+                             (member email (alist-get 'user-mail-identities
+                                                      (cdr alist))))
                      (throw 'exit (car alist))))
                (catch 'exit (mu4e-multi-minibuffer-read-account))))))))
 

--- a/mu4e-multi.el
+++ b/mu4e-multi.el
@@ -203,7 +203,8 @@ keys of the `mu4e-multi-account-alist'."
            (let* ((from (message-fetch-field "from"))
                   (email (and from
                               (string-match thing-at-point-email-regexp from)
-                              (match-string-no-properties 0 from))))
+                              (match-string-no-properties 0 from)))
+                  (email (replace-regexp-in-string "[<>]" "" email)))
              (if email
                  (cl-dolist (alist mu4e-multi-account-alist)
                    (when (string= email (cdr (assoc 'user-mail-address (cdr alist))))


### PR DESCRIPTION
In addition to the primary email address of an account identified by the `user-mail-address` key, there may also be a `user-mail-identities` key which contains a list of email addresses that are treated as aliases to the primary address.
